### PR TITLE
Don't throw exceptions on tabs (0x09) inside strings

### DIFF
--- a/assets/tab_result.hjson
+++ b/assets/tab_result.hjson
@@ -1,0 +1,3 @@
+{
+    name: there is a sneaky	tab here
+}

--- a/assets/tab_result.json
+++ b/assets/tab_result.json
@@ -1,0 +1,3 @@
+{
+  "name": "there is a sneaky\ttab here"
+}

--- a/assets/tab_test.hjson
+++ b/assets/tab_test.hjson
@@ -1,0 +1,3 @@
+{
+    name: there is a sneaky	tab here
+}

--- a/assets/testlist.txt
+++ b/assets/testlist.txt
@@ -84,3 +84,4 @@ stringify/quotes_strings_test.hjson
 extra/notabs_test.json
 extra/root_test.hjson
 extra/separator_test.json
+tab_test.hjson

--- a/src/main/org/hjson/JsonParser.java
+++ b/src/main/org/hjson/JsonParser.java
@@ -200,7 +200,7 @@ class JsonParser {
         pauseCapture();
         readEscape();
         startCapture();
-      } else if (current<0x20) {
+      } else if (current<0x20 && current!=0x09) {
         throw expected("valid string character");
       } else {
         read();


### PR DESCRIPTION
Naive fix to stop throwing exceptions on tabs (0x09) inside strings, e.g.
```
{
  "test": "here be	a tab"
}
```