### PR TITLE
Fixes issues with the Travis-CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,19 @@
-.DS_Store
-gradle
+# Gradle
 .gradle/
+build/
+
+gradle
 gradlew
 gradle.bat
-build/
-hjson.iml
+
+# IntelliJ
+*.iml
 .idea
+
+# Eclipse
+.project
+.classpath
+.settings/
+
+# MacOS
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 jdk:
 - oraclejdk8
-- oraclejdk7
+- openjdk8
+- openjdk11
 env:
   global:
     secure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-- oraclejdk8
 - openjdk8
 - openjdk11
 env:

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ version = '3.0.0'
 group = 'org.hjson'
 description = """Hjson, the Human JSON."""
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 sourceSets {
   main {


### PR DESCRIPTION
Fix for #21 

Updates `travis.yml`
- Removes Oracle JDK 7 and 8
- Add Open JDK 8 and 11

Updates `build.gradle`
- Updates source and target compatibility to 1.8 (was 1.7)

Improves `.gitignore` adds Eclipse, adds some comment, where the excluded files may come from.